### PR TITLE
Changed Raspberry Pi Docker base image to resin/rpi-raspbian:stretch

### DIFF
--- a/DockerfileRPI
+++ b/DockerfileRPI
@@ -1,7 +1,7 @@
-FROM armhf/debian:latest
+FROM resin/rpi-raspbian:stretch
 
 RUN apt-get update -y && \
-  apt-get install -y python3 python3-pip git autoconf automake libtool && \
+  apt-get install -y python3 python3-pip git autoconf automake libtool make && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* build/
 


### PR DESCRIPTION
I had some compile issues with the latest coap libs that require Python 3.5 which is not available in `armhf/debian:latest`. Used `resin/rpi-raspbian:stretch` and include the missing `make` installation. I guess this should also be done for the `development` branch.