### PR TITLE
Add devices.py/ini & colors.py to Docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN pip3 install twisted
 WORKDIR /usr/src/app
 COPY tradfri.tac /usr/src/app
 COPY configure.py /usr/src/app
+COPY colors.py /usr/src/app
+COPY devices.py /usr/src/app
+COPY devices.ini /usr/src/app
 COPY adapter_start.sh /usr/src/app
 
 EXPOSE 1234

--- a/DockerfileRPI
+++ b/DockerfileRPI
@@ -29,6 +29,9 @@ RUN pip3 install twisted
 WORKDIR /usr/src/app
 COPY tradfri.tac /usr/src/app
 COPY configure.py /usr/src/app
+COPY colors.py /usr/src/app
+COPY devices.py /usr/src/app
+COPY devices.ini /usr/src/app
 COPY adapter_start.sh /usr/src/app
 
 EXPOSE 1234


### PR DESCRIPTION
In the Development build the docker files where missing the new devices.py, devices.ini and colors.py.
This caused the adapter to report missing imports. 
```
$docker logs IKEA
Config created!
Traceback (most recent call last):
  File "tradfri.tac", line 21, in <module>
    from devices import ikeaBatteryDevice, ikeaGroup
```
I've updated both the regular and the PI version,  both build successful and now report they are ok:
```
$docker logs IKEA
Config created!
INFO:IKEA-tradfri COAP-adaptor version 0.8.91 started (command line)!
```